### PR TITLE
MCP插件添加超时时间的配置项

### DIFF
--- a/src/i18n/en-US/views.ts
+++ b/src/i18n/en-US/views.ts
@@ -119,6 +119,8 @@ export default {
     author: 'Author',
     homepage: 'Homepage',
     icon: 'Icon',
+    timeout: 'Timeout',
+    timeoutUnit: 's',
     fileParsing: 'File Parsing',
     enable: 'Enable',
     mimeType: 'MIME Type',

--- a/src/i18n/zh-CN/views.ts
+++ b/src/i18n/zh-CN/views.ts
@@ -119,6 +119,8 @@ export default {
     author: '作者',
     homepage: '主页',
     icon: '图标',
+    timeout: '超时时间',
+    timeoutUnit: '秒',
     fileParsing: '文件解析',
     enable: '启用',
     mimeType: 'MIME 类型',

--- a/src/i18n/zh-TW/views.ts
+++ b/src/i18n/zh-TW/views.ts
@@ -119,6 +119,8 @@ export default {
     author: '作者',
     homepage: '主頁',
     icon: '圖示',
+    timeout: '逾時時間',
+    timeoutUnit: '秒',
     fileParsing: '檔案解析',
     enable: '啟用',
     mimeType: 'MIME 類型',

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -33,7 +33,7 @@ export const usePluginsStore = defineStore('plugins', () => {
     ...installed.value.map(i => {
       if (i.type === 'lobechat') return buildLobePlugin(i.manifest, i.available)
       else if (i.type === 'gradio') return buildGradioPlugin(i.manifest, i.available)
-      else return buildMcpPlugin(i.manifest, i.available)
+      else return buildMcpPlugin(i.manifest, i.available, () => data[i.id])
     })
   ])
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -377,6 +377,7 @@ interface PluginData {
   settings
   avatar: Avatar
   fileparsers: Record<string, FileparserData>
+  timeout?: number
 }
 
 type PluginsData = Record<string, PluginData>

--- a/src/views/PluginSettings.vue
+++ b/src/views/PluginSettings.vue
@@ -109,6 +109,20 @@
           component="item"
           lazy
         />
+        <q-item>
+          <q-item-section>{{ $t('pluginSettings.timeout') }}</q-item-section>
+          <q-item-section side>
+            <q-input
+              filled
+              dense
+              type="number"
+              min="1"
+              style="width: 120px"
+              v-model.number="timeoutSeconds"
+              :suffix="$t('pluginSettings.timeoutUnit')"
+            />
+          </q-item-section>
+        </q-item>
       </q-list>
     </q-page>
   </q-page-container>
@@ -126,6 +140,7 @@ import ErrorNotFound from 'src/pages/ErrorNotFound.vue'
 import ListInput from 'src/components/ListInput.vue'
 import JsonInput from 'src/components/JsonInput.vue'
 import { useSetTitle } from 'src/composables/set-title'
+import { MCPRequestTimeout } from 'src/utils/mcp-client'
 
 const props = defineProps<{
   id: string
@@ -135,6 +150,23 @@ defineEmits(['toggle-drawer'])
 
 const pluginsStore = usePluginsStore()
 const { data } = pluginsStore
+
+const timeoutSeconds = computed({
+  get: () => {
+    const pluginData = data[props.id]
+    if (!pluginData) return Math.round(MCPRequestTimeout / 1000)
+    return Math.round(((pluginData.timeout ?? MCPRequestTimeout) / 1000))
+  },
+  set: (val: number) => {
+    const pluginData = data[props.id]
+    if (!pluginData) return
+    if (Number.isFinite(val) && val > 0) {
+      pluginData.timeout = Math.round(val * 1000)
+    } else {
+      pluginData.timeout = undefined
+    }
+  }
+})
 
 const plugin = computed(() => pluginsStore.plugins.find(p => p.id === props.id))
 


### PR DESCRIPTION
**背景**
- 使用 MCP 工具连接本地 ComfyUI 绘图时，因生图耗时较长，默认 60 秒超时经常导致触发 `MCP error -32001: Request timed out`
<img width="1385" height="566" alt="image" src="https://github.com/user-attachments/assets/a14fb1e9-94de-4049-bab8-cbb137c3b8eb" />

**改动内容**
- 为插件新增可配置的超时时间字段（包含 UI 设置项和多语言文案）
- 在 MCP 客户端和插件调用逻辑中引用该配置，覆盖默认超时

**测试情况**
- 本地环境下超时配置功能验证通过
<img width="1827" height="606" alt="image" src="https://github.com/user-attachments/assets/62ea6048-a8c4-4099-88c0-8fcf7fb08ed1" />

**备注**
- 我对前端栈不太熟悉，此次改动使用了 Codex 来完成，如有更优实现或潜在问题，欢迎指出