### PR TITLE
Upgrade dexie-cloud-addon to 4.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "capacitor-stream-fetch": "^0.0.6",
     "codejar-linenumbers": "^1.0.1",
     "dexie": "^4.4.2",
-    "dexie-cloud-addon": "^4.4.10",
+    "dexie-cloud-addon": "^4.4.11",
     "dexie-export-import": "^4.4.0",
     "eventsource": "^3.0.6",
     "expr-eval": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
       dexie-cloud-addon:
-        specifier: ^4.4.10
-        version: 4.4.10(dexie@4.4.2)
+        specifier: ^4.4.11
+        version: 4.4.11(dexie@4.4.2)
       dexie-export-import:
         specifier: ^4.4.0
         version: 4.4.0(dexie@4.4.2)
@@ -3847,8 +3847,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dexie-cloud-addon@4.4.10:
-    resolution: {integrity: sha512-3zrTRixHvIsIeSjhb40ybxM3OlBz25ejnuUaLG/PPBjgDanpeJt26OrMkBkJxulXZAr68EuiL3uQyYl1PttE9w==}
+  dexie-cloud-addon@4.4.11:
+    resolution: {integrity: sha512-0oi0PMgXWujZW82e5sRX9/OMiBCnmhycg8DQRD9VYXMF1HuY2PO4Q/khrx0mX23d+Fn/+maPaWj4pB5fDM7HgQ==}
     engines: {node: '>=14'}
     peerDependencies:
       dexie: ^4.4.2
@@ -4916,11 +4916,6 @@ packages:
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  lib0@0.2.98:
-    resolution: {integrity: sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -11250,7 +11245,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dexie-cloud-addon@4.4.10(dexie@4.4.2):
+  dexie-cloud-addon@4.4.11(dexie@4.4.2):
     dependencies:
       dexie: 4.4.2
       dexie-cloud-common: 1.0.59
@@ -12529,10 +12524,6 @@ snapshots:
       type-check: 0.4.0
 
   lib0@0.2.117:
-    dependencies:
-      isomorphic.js: 0.2.5
-
-  lib0@0.2.98:
     dependencies:
       isomorphic.js: 0.2.5
 
@@ -14731,7 +14722,7 @@ snapshots:
 
   y-protocols@1.0.7(yjs@13.6.30):
     dependencies:
-      lib0: 0.2.98
+      lib0: 0.2.117
       yjs: 13.6.30
 
   y18n@4.0.3: {}


### PR DESCRIPTION
dexie-cloud-addon 4.4.11 includes a bugfix for propagating changes between clients. A bug was introduced in version 4.4.5 that made connected clients realtime updates skip every other update. This bug was not about inconsistency but rather about realtime experience when two clients were simultanously logged in with the same user. The receiving client would only update on every other change. 4.4.11 makes them update on every change.